### PR TITLE
Enable to use environment variables. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tui = { package = "ratatui", version = "0.29", features = ["all-widgets", "cross
 tui-input = { version = "0.10", features = ["crossterm"], default-features = false }
 thiserror = "1.0"
 twelf = { version = "0.15", default-features = false, features = ["toml", "env", "clap"] }
+shellexpand = "3.1"
 
 [dev-dependencies]
 test-log = "0.2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use shellexpand::LookupError;
 use std::{
     env::VarError,
     path::{Path, PathBuf},
@@ -73,10 +74,16 @@ pub enum ToDoError {
     HookFailedToParseError(#[source] FromUtf8Error),
     #[error("Failed to parse hook stdout {0}")]
     HookFailedToParseStdout(#[source] FromUtf8Error),
+    #[error("Failed to exand path {0:?}: {1}")]
+    FailedToExpandPath(PathBuf, #[source] LookupError<VarError>),
 }
 
 impl ToDoError {
     pub fn io_operation_failed(path: impl AsRef<Path>, err: std::io::Error) -> Self {
         Self::IOoperationFailed(path.as_ref().to_path_buf(), err)
+    }
+
+    pub fn path_exapand(path: impl AsRef<Path>, err: LookupError<VarError>) -> Self {
+        Self::FailedToExpandPath(path.as_ref().to_path_buf(), err)
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -124,7 +124,7 @@ impl UI {
         }
 
         let todo = Arc::new(Mutex::new(todo));
-        let file_worker = FileWorker::new(config.file_worker_config.clone(), todo.clone());
+        let file_worker = FileWorker::new(config.file_worker_config.clone(), todo.clone())?;
 
         file_worker.load()?;
         let tx = file_worker.run()?;

--- a/tests/files/test_behaviour_todo.txt
+++ b/tests/files/test_behaviour_todo.txt
@@ -1,2 +1,3 @@
 First task +abcdef
 Second task
+2025-01-05 abc

--- a/tests/files/todotxt-tui/todotxt-tui.toml
+++ b/tests/files/todotxt-tui/todotxt-tui.toml
@@ -1,9 +1,9 @@
 active_color = "Red"
 init_widget = "List"
 window_title = "ToDo tui"
-todo_path = "./tests/files/todotxt-tui/todo.txt"
+todo_path = "$TODO_TUI_TEST_DIR/todotxt-tui/todo.txt"
 # archive_path = "./tests/files/todotxt-tui/archive.txt"
-save_state_path = "./tests/files/todotxt-tui/state.toml"
+save_state_path = "$TODO_TUI_TEST_DIR/files/todotxt-tui/state.toml"
 wrap_preview = true
 file_watcher = true
 list_shift = 4


### PR DESCRIPTION
Enable to use environment variables or ~ for `todo_path` and `archiv_path`.

If path is not utf-8 string variables are not expanded.