### PR TITLE
Add date-based sorting options

### DIFF
--- a/doc/configuration/todo_list.md
+++ b/doc/configuration/todo_list.md
@@ -16,16 +16,22 @@ Determines whether projects, contexts, and tags from completed tasks should be i
 <dd>
 Sorting options to apply to pending tasks. Priority of sorting options is decreasing from left to right. If empty, tasks are not sorted.
 
-- **Possible Values (Flag):** `reverse`, `priority`, `alphanumeric`, `alphanumeric-reverse`  
-- **Possible Values (Config):** `Reverse`, `Priority`, `Alphanumeric`, `AlphanumericReverse`  
+- **Possible Values (Flag):** `reverse`, `priority`, `alphanumeric`, `alphanumeric-reverse`, `create-date-asc`, `create-date-desc`, `finish-date-asc`, `finish-date-desc`, `due-date-asc`, `due-date-desc`
+- **Possible Values (Config):** `Reverse`, `Priority`, `Alphanumeric`, `AlphanumericReverse`, `CreateDateAsc`, `CreateDateDesc`, `FinishDateAsc`, `FinishDateDesc`, `DueDateAsc`, `DueDateDesc`
 - **Default:** `empty`
 
 **Sorting Options**:
 
-- **Reverse:** Reverse the order of tasks.  
-- **Priority:** Sort tasks by priority.  
-- **Alphanumeric:** Sort tasks in alphanumeric order.  
-- **AlphanumericReverse:** Sort tasks in reverse alphanumeric order.  
+- **Reverse:** Reverse the order of tasks.
+- **Priority:** Sort tasks by priority.
+- **Alphanumeric:** Sort tasks in alphanumeric order.
+- **AlphanumericReverse:** Sort tasks in reverse alphanumeric order.
+- **CreateDateAsc:** Sort tasks by creation date, ascending. Tasks without a creation date are placed last.
+- **CreateDateDesc:** Sort tasks by creation date, descending. Tasks without a creation date are placed last.
+- **FinishDateAsc:** Sort tasks by finish date, ascending. Tasks without a finish date are placed last.
+- **FinishDateDesc:** Sort tasks by finish date, descending. Tasks without a finish date are placed last.
+- **DueDateAsc:** Sort tasks by due date, ascending. Tasks without a due date are placed last.
+- **DueDateDesc:** Sort tasks by due date, descending. Tasks without a due date are placed last.
 </dd>
 <br>
 
@@ -35,8 +41,8 @@ Sorting options to apply to pending tasks. Priority of sorting options is decrea
 <dd>
 Sorting options to apply to completed tasks. Priority of sorting options is decreasing from left to right. If empty, tasks are not sorted.
 
-- **Possible Values (Flag):** `reverse`, `priority`, `alphanumeric`, `alphanumeric-reverse`  
-- **Possible Values (Config):** `Reverse`, `Priority`, `Alphanumeric`, `AlphanumericReverse`  
+- **Possible Values (Flag):** `reverse`, `priority`, `alphanumeric`, `alphanumeric-reverse`, `create-date-asc`, `create-date-desc`, `finish-date-asc`, `finish-date-desc`, `due-date-asc`, `due-date-desc`
+- **Possible Values (Config):** `Reverse`, `Priority`, `Alphanumeric`, `AlphanumericReverse`, `CreateDateAsc`, `CreateDateDesc`, `FinishDateAsc`, `FinishDateDesc`, `DueDateAsc`, `DueDateDesc`
 - **Default:** `empty`
 </dd>
 <br>

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -45,6 +45,12 @@ pub enum TaskSort {
     Priority,
     Alphanumeric,
     AlphanumericReverse,
+    CreateDateAsc,
+    CreateDateDesc,
+    FinishDateAsc,
+    FinishDateDesc,
+    DueDateAsc,
+    DueDateDesc,
 }
 
 impl_display!(TaskSort);
@@ -144,6 +150,12 @@ mod tests {
             format!("{}", TaskSort::AlphanumericReverse),
             "alphanumeric-reverse"
         );
+        assert_eq!(format!("{}", TaskSort::CreateDateAsc), "create-date-asc");
+        assert_eq!(format!("{}", TaskSort::CreateDateDesc), "create-date-desc");
+        assert_eq!(format!("{}", TaskSort::FinishDateAsc), "finish-date-asc");
+        assert_eq!(format!("{}", TaskSort::FinishDateDesc), "finish-date-desc");
+        assert_eq!(format!("{}", TaskSort::DueDateAsc), "due-date-asc");
+        assert_eq!(format!("{}", TaskSort::DueDateDesc), "due-date-desc");
     }
 
     #[test]

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -204,7 +204,7 @@ impl ToDo {
     /// # Returns
     ///
     /// A `TaskList` containing the filtered and sorted tasks.
-    pub fn get_filtered_and_sorted(&self, data: ToDoData) -> TaskList<'_> {
+    pub fn get_filtered_and_sorted(&self, data: ToDoData) -> TaskList<'_, '_> {
         let mut task_list = TaskList::new(self.get_filtered_tasks(data), &self.styles);
         task_list.sort(data.get_sorting(&self.config));
         task_list

--- a/src/todo/task_list.rs
+++ b/src/todo/task_list.rs
@@ -18,9 +18,9 @@ type Item<'a> = (usize, &'a Task);
 
 /// Represents a list of tasks, where each task is a tuple of `(usize, &'a Task)`.
 /// The `usize` value is the index of the task in the original list.
-pub struct TaskList<'a> {
+pub struct TaskList<'a, 'b> {
     vec: Vec<Item<'a>>,
-    styles: &'a Styles,
+    styles: &'b Styles,
 }
 
 pub struct TaskView<'a> {
@@ -31,9 +31,9 @@ pub struct TaskView<'a> {
     todo: &'a ToDo,
 }
 
-impl<'a> TaskList<'a> {
+impl<'a, 'b> TaskList<'a, 'b> {
     /// Creates a new `TaskList` instance.
-    pub fn new(vec: Vec<Item<'a>>, styles: &'a Styles) -> Self {
+    pub fn new(vec: Vec<Item<'a>>, styles: &'b Styles) -> Self {
         Self { vec, styles }
     }
 
@@ -108,25 +108,47 @@ impl<'a> TaskList<'a> {
             TaskSort::Reverse => self.vec.reverse(),
             TaskSort::Priority => self
                 .vec
-                .sort_by(|(_, a_task), (_, b_task)| b_task.priority.cmp(&a_task.priority)),
-            TaskSort::Alphanumeric => self
+                .sort_by(|(_, a), (_, b)| b.priority.cmp(&a.priority)),
+            TaskSort::Alphanumeric => self.vec.sort_by(|(_, a), (_, b)| a.subject.cmp(&b.subject)),
+            TaskSort::AlphanumericReverse => {
+                self.vec.sort_by(|(_, a), (_, b)| b.subject.cmp(&a.subject))
+            }
+            TaskSort::CreateDateAsc => self
                 .vec
-                .sort_by(|(_, a_task), (_, b_task)| a_task.subject.cmp(&b_task.subject)),
-            TaskSort::AlphanumericReverse => self
+                .sort_by_key(|(_, t)| (t.create_date.is_none(), t.create_date)),
+            TaskSort::CreateDateDesc => self.vec.sort_by_key(|(_, t)| {
+                (
+                    t.create_date.is_none(),
+                    t.create_date.map(std::cmp::Reverse),
+                )
+            }),
+            TaskSort::FinishDateAsc => self
                 .vec
-                .sort_by(|(_, a_task), (_, b_task)| b_task.subject.cmp(&a_task.subject)),
+                .sort_by_key(|(_, t)| (t.finish_date.is_none(), t.finish_date)),
+            TaskSort::FinishDateDesc => self.vec.sort_by_key(|(_, t)| {
+                (
+                    t.finish_date.is_none(),
+                    t.finish_date.map(std::cmp::Reverse),
+                )
+            }),
+            TaskSort::DueDateAsc => self
+                .vec
+                .sort_by_key(|(_, t)| (t.due_date.is_none(), t.due_date)),
+            TaskSort::DueDateDesc => self
+                .vec
+                .sort_by_key(|(_, t)| (t.due_date.is_none(), t.due_date.map(std::cmp::Reverse))),
         });
     }
 }
 
-impl<'a> Index<usize> for TaskList<'a> {
+impl<'a, 'b> Index<usize> for TaskList<'a, 'b> {
     type Output = Task;
-    fn index<'b>(&'b self, i: usize) -> &'a Task {
+    fn index<'c>(&'c self, i: usize) -> &'a Task {
         self.vec[i].1
     }
 }
 
-impl Searchable for TaskList<'_> {
+impl<'a, 'b> Searchable for TaskList<'a, 'b> {
     fn search_through(&self) -> impl DoubleEndedIterator + ExactSizeIterator<Item = &str> {
         self.vec.iter().map(|item| item.1.subject.as_str())
     }
@@ -160,15 +182,17 @@ impl<'a> From<TaskView<'a>> for List<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::Result;
+    use pretty_assertions::assert_eq;
     use std::str::FromStr;
 
     #[test]
-    fn task_slice() {
+    fn task_slice() -> Result<()> {
         let styles = Styles::default();
-        let task1 = Task::from_str("measure space for 1").unwrap();
-        let task2 = Task::from_str("measure space for 2").unwrap();
-        let task3 = Task::from_str("measure space for 3").unwrap();
-        let task4 = Task::from_str("measure space for 4").unwrap();
+        let task1 = Task::from_str("measure space for 1")?;
+        let task2 = Task::from_str("measure space for 2")?;
+        let task3 = Task::from_str("measure space for 3")?;
+        let task4 = Task::from_str("measure space for 4")?;
         let tasklist = TaskList {
             vec: vec![(0, &task1), (1, &task2), (2, &task3), (3, &task4)],
             styles: &styles,
@@ -186,96 +210,86 @@ mod tests {
         assert_eq!(slice.vec[0], (1, &task2));
         assert_eq!(slice.vec[1], (2, &task3));
         assert_eq!(slice.vec[2], (3, &task4));
+
+        Ok(())
     }
 
     #[test]
-    fn sort_tasklist() {
-        let compare = |expected: &TaskList, real: TaskList| {
-            assert_eq!(expected.len(), real.len());
-            for i in 0..expected.len() {
-                assert_eq!(expected[i], real[i]);
-            }
-        };
-        let styles = Styles::default();
-        let task1 = Task::from_str("(C) 2 measure space for 1").unwrap();
-        let task2 = Task::from_str("    3 measure space for 2").unwrap();
-        let task3 = Task::from_str("    1 measure space for 3").unwrap();
-        let task4 = Task::from_str("(A) 4 measure space for 4").unwrap();
-        let tasklist = TaskList {
-            vec: vec![(0, &task1), (1, &task2), (2, &task3), (3, &task4)],
-            styles: &styles,
+    fn sort_tasklist() -> Result<()> {
+        let task0 = Task::from_str("(C) 2026-03-28 2026-03-25 2 measure space for 1")?;
+        let task1 = Task::from_str("2026-03-24 3 measure space for 2 due:2026-04-03")?;
+        let task2 = Task::from_str("1 measure space for 3 due:2026-04-02")?;
+        let task3 = Task::from_str("(A) 2026-03-30 2026-03-22 4 measure space for 4")?;
+
+        let get_sorted = |filters| {
+            let mut list = TaskList {
+                vec: vec![(0, &task0), (1, &task1), (2, &task2), (3, &task3)],
+                styles: &Styles::default(),
+            };
+            list.sort(filters);
+            list.vec
         };
 
-        let mut none = TaskList {
-            vec: vec![(0, &task1), (1, &task2), (2, &task3), (3, &task4)],
-            styles: &styles,
-        };
-        none.sort(&[]);
-        compare(&tasklist, none);
-
-        let mut reverse = TaskList {
-            vec: vec![(0, &task1), (1, &task2), (2, &task3), (3, &task4)],
-            styles: &styles,
-        };
-        reverse.sort(&[TaskSort::Reverse]);
-        compare(
-            &TaskList {
-                vec: vec![(3, &task4), (2, &task3), (1, &task2), (0, &task1)],
-                styles: &styles,
-            },
-            reverse,
+        assert_eq!(
+            vec![(0, &task0), (1, &task1), (2, &task2), (3, &task3)],
+            get_sorted(&[])
         );
 
-        let mut priority = TaskList {
-            vec: vec![(0, &task1), (1, &task2), (2, &task3), (3, &task4)],
-            styles: &styles,
-        };
-        priority.sort(&[TaskSort::Priority]);
-        compare(
-            &TaskList {
-                vec: vec![(3, &task4), (0, &task1), (1, &task2), (2, &task3)],
-                styles: &styles,
-            },
-            priority,
+        assert_eq!(
+            vec![(3, &task3), (2, &task2), (1, &task1), (0, &task0)],
+            get_sorted(&[TaskSort::Reverse])
         );
 
-        let mut alpha = TaskList {
-            vec: vec![(0, &task1), (1, &task2), (2, &task3), (3, &task4)],
-            styles: &styles,
-        };
-        alpha.sort(&[TaskSort::Alphanumeric]);
-        compare(
-            &TaskList {
-                vec: vec![(2, &task3), (0, &task1), (1, &task2), (3, &task4)],
-                styles: &styles,
-            },
-            alpha,
+        assert_eq!(
+            vec![(3, &task3), (0, &task0), (1, &task1), (2, &task2)],
+            get_sorted(&[TaskSort::Priority])
         );
 
-        let mut alpha_reverse = TaskList {
-            vec: vec![(0, &task1), (1, &task2), (2, &task3), (3, &task4)],
-            styles: &styles,
-        };
-        alpha_reverse.sort(&[TaskSort::AlphanumericReverse]);
-        compare(
-            &TaskList {
-                vec: vec![(3, &task4), (1, &task2), (0, &task1), (2, &task3)],
-                styles: &styles,
-            },
-            alpha_reverse,
+        assert_eq!(
+            vec![(2, &task2), (0, &task0), (1, &task1), (3, &task3)],
+            get_sorted(&[TaskSort::Alphanumeric])
         );
 
-        let mut multi_sort = TaskList {
-            vec: vec![(0, &task1), (1, &task2), (2, &task3), (3, &task4)],
-            styles: &styles,
-        };
-        multi_sort.sort(&[TaskSort::Priority, TaskSort::Alphanumeric]);
-        compare(
-            &TaskList {
-                vec: vec![(3, &task4), (0, &task1), (2, &task3), (1, &task2)],
-                styles: &styles,
-            },
-            multi_sort,
+        assert_eq!(
+            vec![(3, &task3), (1, &task1), (0, &task0), (2, &task2)],
+            get_sorted(&[TaskSort::AlphanumericReverse])
         );
+
+        assert_eq!(
+            vec![(3, &task3), (0, &task0), (2, &task2), (1, &task1)],
+            get_sorted(&[TaskSort::Priority, TaskSort::Alphanumeric])
+        );
+
+        assert_eq!(
+            vec![(3, &task3), (1, &task1), (0, &task0), (2, &task2)],
+            get_sorted(&[TaskSort::CreateDateAsc])
+        );
+
+        assert_eq!(
+            vec![(0, &task0), (1, &task1), (3, &task3), (2, &task2)],
+            get_sorted(&[TaskSort::CreateDateDesc])
+        );
+
+        assert_eq!(
+            vec![(0, &task0), (3, &task3), (1, &task1), (2, &task2)],
+            get_sorted(&[TaskSort::FinishDateAsc])
+        );
+
+        assert_eq!(
+            vec![(3, &task3), (0, &task0), (1, &task1), (2, &task2)],
+            get_sorted(&[TaskSort::FinishDateDesc])
+        );
+
+        assert_eq!(
+            vec![(2, &task2), (1, &task1), (0, &task0), (3, &task3)],
+            get_sorted(&[TaskSort::DueDateAsc])
+        );
+
+        assert_eq!(
+            vec![(1, &task1), (2, &task2), (0, &task0), (3, &task3)],
+            get_sorted(&[TaskSort::DueDateDesc])
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Add CreateDateAsc/Desc, FinishDataAsc/Desc, and DueDateAsc/Desc sort options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sorting by creation date, finish date, and due date (ascending and descending) for --pending-sort and --done-sort; items missing the relevant date are placed last.

* **Documentation**
  * Updated configuration docs to describe the new date-based sorting modes and their behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->