### PR TITLE
Fix panics when last list item is removed when post-move/-remove hooks are used

### DIFF
--- a/src/todo.rs
+++ b/src/todo.rs
@@ -160,11 +160,6 @@ impl ToDo {
         };
 
         let (from, to) = pair;
-        if from.len() <= index {
-            // Rather low risk of getting here, but just in case.
-            self.fix_active(index);
-            return;
-        }
         let task = from.remove(index);
         let finalized = move_task_logic(task);
         let finalized_str = finalized.to_string();

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -136,11 +136,7 @@ impl ToDo {
             }
         };
 
-        let move_task_logic = |from: &mut Vec<Task>, to: &mut Vec<_>| {
-            if from.len() <= index {
-                return;
-            }
-            let mut task = from.remove(index);
+        let move_task_logic = |mut task: Task| -> Task {
             if task.finished && self.config.delete_final_date {
                 task.finish_date = None;
             }
@@ -154,18 +150,26 @@ impl ToDo {
                 }
             }
             task.finished = !task.finished;
-            to.push(task)
+            task
         };
-        self.hooks.run_lazy(HookTypes::PreMove, || {
-            data.get_data(self)[index].to_string()
-        });
-        match data {
-            ToDoData::Pending => move_task_logic(&mut self.pending, &mut self.done),
-            ToDoData::Done => move_task_logic(&mut self.done, &mut self.pending),
+        let pre_task_str = data.get_data(self)[index].to_string();
+        self.hooks.run(HookTypes::PreMove, &pre_task_str);
+        let pair = match data {
+            ToDoData::Pending => (&mut self.pending, &mut self.done),
+            ToDoData::Done => (&mut self.done, &mut self.pending),
         };
-        self.hooks.run_lazy(HookTypes::PostMove, || {
-            data.get_data(self)[index].to_string()
-        });
+
+        let (from, to) = pair;
+        if from.len() <= index {
+            // Rather low risk of getting here, but just in case.
+            self.fix_active(index);
+            return;
+        }
+        let task = from.remove(index);
+        let finalized = move_task_logic(task);
+        let finalized_str = finalized.to_string();
+        to.push(finalized);
+        self.hooks.run(HookTypes::PostMove, finalized_str);
         self.fix_active(index)
     }
 

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -233,6 +233,7 @@ impl ToDo {
         if task.create_date.is_none() && self.config.set_created_date {
             task.create_date = Some(Self::get_actual_date());
         }
+        let final_task_str = task.to_string();
         if task.finished {
             self.done.push(task);
             self.version.update(&ToDoData::Done);
@@ -240,7 +241,7 @@ impl ToDo {
             self.pending.push(task);
             self.version.update(&ToDoData::Pending);
         }
-        self.hooks.run(HookTypes::PostNew, &task_str);
+        self.hooks.run(HookTypes::PostNew, &final_task_str);
         Ok(())
     }
 

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -249,13 +249,10 @@ impl ToDo {
     pub fn remove_task(&mut self, data: ToDoData, index: usize) {
         let index = self.get_actual_index(data, index);
         if let Some(index) = index {
-            self.hooks.run_lazy(HookTypes::PreRemove, || {
-                data.get_data(self)[index].to_string()
-            });
+            let task_str = data.get_data(self)[index].to_string();
+            self.hooks.run(HookTypes::PreRemove, &task_str);
             data.get_data_mut(self).remove(index);
-            self.hooks.run_lazy(HookTypes::PostRemove, || {
-                data.get_data(self)[index].to_string()
-            });
+            self.hooks.run(HookTypes::PostRemove, &task_str);
             self.fix_active(index);
         } else {
             log::warn!("Layout::get_actual_index is None");

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -366,8 +366,10 @@ impl ToDo {
             if let Some(new_task) = self.hooks.run(HookTypes::PreUpdate, &task) {
                 task = new_task;
             }
-            data.get_data_mut(self)[index] = Task::from_str(&task)?;
-            self.hooks.run(HookTypes::PostUpdate, &task);
+            let new_task = Task::from_str(&task)?;
+            let final_task_str = new_task.to_string();
+            data.get_data_mut(self)[index] = new_task;
+            self.hooks.run(HookTypes::PostUpdate, &final_task_str);
         }
         Ok(())
     }

--- a/src/todo/hooks.rs
+++ b/src/todo/hooks.rs
@@ -113,16 +113,6 @@ impl Hooks {
             &hook_type.to_string(),
         )
     }
-
-    /// Runs the hook for the given type, lazily evaluating the task string only
-    /// if the hook is configured. Returns `Some(stdout)` on success, `None` otherwise.
-    pub fn run_lazy(&self, hook_type: HookTypes, task: impl Fn() -> String) -> Option<String> {
-        Self::run_command_with_name(
-            self.get_path(&hook_type)?,
-            task().as_ref(),
-            &hook_type.to_string(),
-        )
-    }
 }
 
 #[cfg(test)]
@@ -190,73 +180,6 @@ mod tests {
             hooks.run(HookTypes::PostUpdate, "post update"),
             Some(String::from("hook: post update"))
         );
-
-        assert_eq!(
-            hooks.run_lazy(HookTypes::PreNew, || String::from("pre new")),
-            Some(String::from("hook: pre new"))
-        );
-        assert_eq!(
-            hooks.run_lazy(HookTypes::PostNew, || String::from("post new")),
-            Some(String::from("hook: post new"))
-        );
-        assert_eq!(
-            hooks.run_lazy(HookTypes::PreRemove, || String::from("pre remove")),
-            Some(String::from("hook: pre remove"))
-        );
-        assert_eq!(
-            hooks.run_lazy(HookTypes::PostRemove, || String::from("post remove")),
-            Some(String::from("hook: post remove"))
-        );
-        assert_eq!(
-            hooks.run_lazy(HookTypes::PreMove, || String::from("pre move")),
-            Some(String::from("hook: pre move"))
-        );
-        assert_eq!(
-            hooks.run_lazy(HookTypes::PostMove, || String::from("post move")),
-            Some(String::from("hook: post move"))
-        );
-        assert_eq!(
-            hooks.run_lazy(HookTypes::PreUpdate, || String::from("pre update")),
-            Some(String::from("hook: pre update"))
-        );
-        assert_eq!(
-            hooks.run_lazy(HookTypes::PostUpdate, || String::from("post update")),
-            Some(String::from("hook: post update"))
-        );
-    }
-
-    #[test]
-    fn run_lazy_skips_closure_when_no_path() {
-        let hooks = Hooks::new(HookPaths::default());
-        let called = std::cell::Cell::new(false);
-        let result = hooks.run_lazy(HookTypes::PreNew, || {
-            called.set(true);
-            String::from("should not be evaluated")
-        });
-        assert_eq!(result, None);
-        assert!(
-            !called.get(),
-            "closure should not be called when no hook path is configured"
-        );
-    }
-
-    #[test]
-    fn run_lazy_evaluates_closure_when_path_configured() {
-        let path = PathBuf::from(var("TODO_TUI_TEST_DIR").unwrap()).join("hook.sh");
-        let hooks = Hooks::new(HookPaths {
-            pre_new_task: Some(path),
-            ..HookPaths::default()
-        });
-        let called = std::cell::Cell::new(false);
-        let result = hooks.run_lazy(HookTypes::PreNew, || {
-            called.set(true);
-            String::from("lazy task")
-        });
-        assert!(
-            called.get(),
-            "closure should be called when hook path is configured"
-        );
-        assert_eq!(result, Some(String::from("hook: lazy task")));
     }
 
     #[test]


### PR DESCRIPTION
This fixes the access-after-remove errors by grabbing `Task`'s string representation before the removal happens. Since every instance of this bug happened in `run_lazy`, this removes it as well (I don't imagine the performance penalty will be large).

It also changes one semantic: the post-move hook now receives the task after it's been modified by the move logic. It felt as a right and logical fix while I was there, but let me know and I'll revert it!

Fixes #78.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task move behavior and made hook payloads consistent by capturing task details before/after the move.
  * Ensured task hooks receive the finalized task details during creation, moving, removal, and updates.
* **Refactor**
  * Updated hook payload handling to use eager task snapshots for more predictable results.
* **Tests**
  * Removed tests covering prior lazy hook-evaluation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->